### PR TITLE
add browserify support

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,5 @@
+build
+component.json
+components
+Makefile
 test

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,13 @@
 build: index.js template.js components
 	@component build --dev
 
+build-browserify: $(SRC) node_modules
+	@mkdir -p build
+	@browserify \
+		--require query \
+		--require ./index.js:popover \
+		--outfile build/build.js
+
 template.js: template.html
 	@component convert $<
 
@@ -11,4 +18,4 @@ components:
 clean:
 	rm -fr build components
 
-.PHONY: clean
+.PHONY: clean build

--- a/package.json
+++ b/package.json
@@ -11,9 +11,14 @@
     "url": "https://github.com/component/popover.git"
   },
   "dependencies": {
-    "tip-component": "*",
+    "component-tip": "*",
     "component-query": "*",
     "component-inherit": "0.0.3"
+  },
+  "browser": {
+    "inherit": "component-inherit",
+    "query": "component-query",
+    "tip": "component-tip"
   },
   "component": {
     "scripts": {

--- a/test/index.html
+++ b/test/index.html
@@ -36,7 +36,7 @@
     <a href="#" id="markup">Markup</a>
     <a href="#" id="auto">Auto</a>
     <script>
-      var q = require('component-query');
+      var q = require('query');
       var Popover = require('popover');
       Popover.effect = 'fade';
 


### PR DESCRIPTION
fix package.json - add browser section, rename tip-component -> component-tip

make `build-browserify` target is added as an alternative to component build - mostly to allow for independent testing
